### PR TITLE
feat: make Baileys URL configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
 # Here are your Instructions
+
+## Environment Variables
+
+### `BAILEYS_URL`
+
+The Baileys integration no longer relies on hard-coded URLs. All modules now read the
+Baileys service location from the `BAILEYS_URL` environment variable. If not provided,
+`http://localhost:3002` is used by default.
+
+Example usage:
+
+```bash
+export BAILEYS_URL=http://baileys.internal:3002
+python whatsflow-real.py
+```
+
+For the Node.js service:
+
+```bash
+BAILEYS_URL=http://baileys.internal:3002 node baileys_service/server.js
+```

--- a/backend_test.py
+++ b/backend_test.py
@@ -8,12 +8,13 @@ Testing the 3 critical problems reported in the review request:
 3. "Layout da área de mensagens muito feio e antiprofissional" (Backend support for professional interface)
 
 Expected corrections:
-1. URLs changed from localhost:3002 to 127.0.0.1:3002 in frontend JavaScript
+1. URLs moved to configurable BAILEYS_URL environment variable
 2. /groups/{instanceId} endpoint implemented in Baileys service
 3. CORS configuration updated to accept both localhost and 127.0.0.1
 4. Design completely renovated with elegant and professional interface
 """
 
+import os
 import requests
 import json
 import time
@@ -25,7 +26,7 @@ class WhatsFlowTester:
     def __init__(self):
         # Service URLs based on the review request
         self.whatsflow_url = "http://127.0.0.1:8889"  # WhatsFlow Real Python service
-        self.baileys_url = "http://127.0.0.1:3002"    # Baileys Node.js service
+        self.baileys_url = os.getenv("BAILEYS_URL", "http://localhost:3002")    # Baileys Node.js service
         self.frontend_url = "http://127.0.0.1:3000"   # Frontend React service
         
         self.test_results = []
@@ -67,7 +68,7 @@ class WhatsFlowTester:
     def test_baileys_connectivity(self) -> bool:
         """
         TESTE 1: Conectividade Frontend-Baileys
-        Teste fetch direto de http://127.0.0.1:3002/health
+        Teste fetch direto de ${BAILEYS_URL}/health
         """
         print("🔍 TESTE 1: CONECTIVIDADE FRONTEND-BAILEYS")
         print("-" * 50)
@@ -118,7 +119,7 @@ class WhatsFlowTester:
     def test_groups_endpoint(self) -> bool:
         """
         TESTE 2: Groups Endpoint
-        Teste GET http://127.0.0.1:3002/groups/test-instance
+        Teste GET ${BAILEYS_URL}/groups/test-instance
         """
         print("🔍 TESTE 2: GROUPS ENDPOINT")
         print("-" * 50)
@@ -198,7 +199,7 @@ class WhatsFlowTester:
     def test_send_endpoint(self) -> bool:
         """
         TESTE 3: Send Endpoint
-        Teste POST http://127.0.0.1:3002/send/test-instance
+        Teste POST ${BAILEYS_URL}/send/test-instance
         """
         print("🔍 TESTE 3: SEND ENDPOINT")
         print("-" * 50)

--- a/backend_test_corrections.py
+++ b/backend_test_corrections.py
@@ -26,7 +26,7 @@ import os
 # Configuration - Testing all backend systems
 WHATSFLOW_URL = "http://localhost:8889"  # WhatsFlow Real standalone
 BACKEND_URL = "http://localhost:8001"    # FastAPI backend (supervisor)
-BAILEYS_URL = "http://localhost:3002"    # Baileys Node.js service
+BAILEYS_URL = os.getenv("BAILEYS_URL", "http://localhost:3002")    # Baileys Node.js service
 FRONTEND_URL = "http://localhost:3000"   # React frontend
 
 # API endpoints

--- a/baileys_service/server.js
+++ b/baileys_service/server.js
@@ -552,8 +552,9 @@ app.get('/health', (req, res) => {
 });
 
 const PORT = process.env.PORT || 3002;
+const BAILEYS_URL = process.env.BAILEYS_URL || `http://localhost:${PORT}`;
 app.listen(PORT, '0.0.0.0', () => {
     console.log(`🚀 Baileys service rodando na porta ${PORT}`);
-    console.log(`📊 Health check: http://localhost:${PORT}/health`);
+    console.log(`📊 Health check: ${BAILEYS_URL}/health`);
     console.log('⏳ Aguardando comandos para conectar instâncias...');
 });

--- a/corrected_review_test.py
+++ b/corrected_review_test.py
@@ -14,7 +14,7 @@ import os
 
 # Configuration based on review request
 WHATSFLOW_URL = "http://localhost:8889"
-BAILEYS_URL = "http://localhost:3002"
+BAILEYS_URL = os.getenv("BAILEYS_URL", "http://localhost:3002")
 FRONTEND_URL = "http://localhost:3000"
 WHATSFLOW_API = f"{WHATSFLOW_URL}/api"
 

--- a/critical_fixes_test.py
+++ b/critical_fixes_test.py
@@ -13,6 +13,7 @@ SERVICES TO TEST:
 - Baileys Node.js (porta 3002) - PID 14067
 """
 
+import os
 import requests
 import json
 import time
@@ -21,7 +22,7 @@ from datetime import datetime
 class CriticalFixesTester:
     def __init__(self):
         self.whatsflow_url = "http://localhost:8889"
-        self.baileys_url = "http://localhost:3002"
+        self.baileys_url = os.getenv("BAILEYS_URL", "http://localhost:3002")
         self.session = requests.Session()
         self.test_results = []
         

--- a/final_backend_test.py
+++ b/final_backend_test.py
@@ -9,6 +9,7 @@ This test focuses on the specific corrections mentioned in the review request:
 4. Layout improvements
 """
 
+import os
 import requests
 import json
 import time
@@ -17,7 +18,7 @@ from datetime import datetime
 # Configuration
 WHATSFLOW_URL = "http://localhost:8889"
 BACKEND_URL = "http://localhost:8001"
-BAILEYS_URL = "http://localhost:3002"
+BAILEYS_URL = os.getenv("BAILEYS_URL", "http://localhost:3002")
 FRONTEND_URL = "http://localhost:3000"
 
 WHATSFLOW_API = f"{WHATSFLOW_URL}/api"

--- a/final_critical_fixes_test.py
+++ b/final_critical_fixes_test.py
@@ -30,7 +30,7 @@ import os
 
 # Configuration
 WHATSFLOW_REAL_URL = "http://localhost:8889"
-BAILEYS_SERVICE_URL = "http://localhost:3002"
+BAILEYS_SERVICE_URL = os.getenv("BAILEYS_URL", "http://localhost:3002")
 BACKEND_API_URL = "http://localhost:8001/api"
 FRONTEND_URL = "http://localhost:3000"
 

--- a/final_review_validation.py
+++ b/final_review_validation.py
@@ -13,6 +13,7 @@ Validating all specific corrections from review request:
 7. Envio de mensagens Baileys - URL corrigida
 """
 
+import os
 import requests
 import json
 import re
@@ -21,7 +22,7 @@ from datetime import datetime
 class FinalReviewValidator:
     def __init__(self):
         self.whatsflow_url = "http://localhost:8889"
-        self.baileys_url = "http://localhost:3002"
+        self.baileys_url = os.getenv("BAILEYS_URL", "http://localhost:3002")
         self.session = requests.Session()
         self.validations = []
         

--- a/focused_backend_test.py
+++ b/focused_backend_test.py
@@ -19,7 +19,7 @@ from datetime import datetime
 
 # Configuration
 WHATSFLOW_URL = "http://localhost:8889"
-BAILEYS_URL = "http://localhost:3002"
+BAILEYS_URL = os.getenv("BAILEYS_URL", "http://localhost:3002")
 FRONTEND_URL = "http://localhost:3000"
 WHATSFLOW_API = f"{WHATSFLOW_URL}/api"
 

--- a/review_corrections_test.py
+++ b/review_corrections_test.py
@@ -27,7 +27,7 @@ from datetime import datetime
 
 # Configuration
 WHATSFLOW_URL = "http://localhost:8889"
-BAILEYS_URL = "http://localhost:3002"
+BAILEYS_URL = os.getenv("BAILEYS_URL", "http://localhost:3002")
 DB_FILE = "/app/whatsflow.db"
 
 class ReviewCorrectionsValidator:

--- a/review_request_final_test.py
+++ b/review_request_final_test.py
@@ -34,7 +34,7 @@ import os
 
 # Configuration
 WHATSFLOW_URL = "http://localhost:8889"
-BAILEYS_URL = "http://localhost:3002"
+BAILEYS_URL = os.getenv("BAILEYS_URL", "http://localhost:3002")
 FRONTEND_URL = "http://localhost:3000"
 
 class ReviewRequestFinalTester:

--- a/review_request_test.py
+++ b/review_request_test.py
@@ -30,7 +30,7 @@ import os
 
 # Configuration based on review request
 WHATSFLOW_URL = "http://localhost:8889"
-BAILEYS_URL = "http://localhost:3002"
+BAILEYS_URL = os.getenv("BAILEYS_URL", "http://localhost:3002")
 FRONTEND_URL = "http://localhost:3000"
 WHATSFLOW_API = f"{WHATSFLOW_URL}/api"
 


### PR DESCRIPTION
## Summary
- read Baileys service location from `BAILEYS_URL` environment variable
- update WhatsFlow, Baileys server and tests to use the configurable URL
- document `BAILEYS_URL` usage in README

## Testing
- `python -m py_compile whatsflow-real.py backend_test.py review_request_test.py backend_test_corrections.py final_backend_test.py focused_backend_test.py final_review_validation.py corrected_review_test.py critical_fixes_test.py review_corrections_test.py review_request_final_test.py final_critical_fixes_test.py`
- `node --check baileys_service/server.js`


------
https://chatgpt.com/codex/tasks/task_e_68c18f52dde8832fabba69dd42f46e3f