### PR TITLE
fix send route and improve error handling

### DIFF
--- a/whatsflow-real.py
+++ b/whatsflow-real.py
@@ -3544,7 +3544,7 @@ HTML_APP = r'''<!DOCTYPE html>
             }
             
             try {
-                const response = await fetch(`/api/send/${instanceId}`, {
+                const response = await fetch(`/api/messages/send/${instanceId}`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({
@@ -3553,15 +3553,17 @@ HTML_APP = r'''<!DOCTYPE html>
                         type: 'text'
                     })
                 });
-                
+
                 const result = await response.json();
-                
-                if (response.ok && result.success) {
+
+                if (response.status === 503) {
+                    alert(`❌ ${result.error || 'Baileys service não disponível'}`);
+                } else if (response.ok && result.success) {
                     alert('✅ Mensagem enviada para o grupo com sucesso!');
                 } else {
                     throw new Error(result.error || 'Erro ao enviar mensagem');
                 }
-                
+
             } catch (error) {
                 console.error('❌ Erro ao enviar mensagem para grupo:', error);
                 if (error.message.includes('fetch') || error instanceof TypeError) {


### PR DESCRIPTION
## Summary
- Align group send API call with backend `/api/messages/send` endpoint
- Surface Baileys service outages via 503 handling on group message send

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'requests'; SyntaxError in tests/test_baileys_unavailable.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c1bf220608832fabe8763f6e5eea9e