### PR TITLE
fix malformed SQL in init_db schema

### DIFF
--- a/whatsflow-real.py
+++ b/whatsflow-real.py
@@ -3738,7 +3738,6 @@ def init_db():
     """)
 
     cursor.execute("""
-codex/add-periodic-background-task-for-campaign-messages
         CREATE TABLE IF NOT EXISTS campaign_messages (
             id TEXT PRIMARY KEY,
             phone TEXT NOT NULL,
@@ -3747,7 +3746,6 @@ codex/add-periodic-background-task-for-campaign-messages
             send_time TEXT NOT NULL,
             weekdays TEXT,
             last_sent_at TEXT
-
         )
     """)
     


### PR DESCRIPTION
## Summary
- remove stray codex line before campaign_messages table in `init_db`
- ensure `campaign_messages` table creation uses valid SQLite syntax

## Testing
- `python -m py_compile whatsflow-real.py`
- `python - <<'PY'
import importlib.util
spec = importlib.util.spec_from_file_location('whatsflow_real', 'whatsflow-real.py')
mod = importlib.util.module_from_spec(spec)
spec.loader.exec_module(mod)
mod.init_db()
PY`

------
https://chatgpt.com/codex/tasks/task_e_68c1c78f9008832fb0fc60e7ad233ace