### PR TITLE
Add campaign navigation and management UI

### DIFF
--- a/frontend/src/components/Campaigns.js
+++ b/frontend/src/components/Campaigns.js
@@ -146,7 +146,11 @@ function CampaignForm({ initialData, onSave, onCancel }) {
       </div>
       <div className="form-row">
         <label>Mídia</label>
-        <input type="file" onChange={e => setMedia(e.target.files[0])} />
+        <input
+          type="file"
+          accept="text/plain,image/*,audio/*,video/*"
+          onChange={e => setMedia(e.target.files[0])}
+        />
       </div>
       <div className="form-actions">
         <button type="button" onClick={onCancel}>Cancelar</button>
@@ -183,6 +187,17 @@ export default function Campaigns() {
     fetchCampaigns();
   };
 
+  const handleDelete = async (id) => {
+    if (!window.confirm('Excluir campanha?')) return;
+    try {
+      await axios.delete(`${API}/campaigns/${id}`);
+      fetchCampaigns();
+    } catch (err) {
+      console.error('Erro ao excluir campanha', err);
+      alert('Erro ao excluir campanha');
+    }
+  };
+
   if (loading) {
     return <div className="loading">Carregando campanhas...</div>;
   }
@@ -214,7 +229,10 @@ export default function Campaigns() {
                 </div>
               )}
             </div>
-            <button onClick={() => { setEditing(c); setShowForm(true); }}>Editar</button>
+            <div className="campaign-actions">
+              <button onClick={() => { setEditing(c); setShowForm(true); }}>Editar</button>
+              <button onClick={() => handleDelete(c.id)}>Excluir</button>
+            </div>
           </div>
         ))}
       </div>

--- a/whatsflow-real.py
+++ b/whatsflow-real.py
@@ -1841,6 +1841,9 @@ HTML_APP = r'''<!DOCTYPE html>
             <button class="nav-btn" onclick="showSection('flows')">
                 <span>🎯</span> Fluxos
             </button>
+            <button class="nav-btn" onclick="showSection('campaigns')">
+                <span>📢</span> Campanhas
+            </button>
         </nav>
         
         <div id="dashboard" class="section active">
@@ -2044,8 +2047,14 @@ HTML_APP = r'''<!DOCTYPE html>
                 </div>
             </div>
         </div>
+        <div id="campaigns" class="section">
+            <div class="card">
+                <h2>📢 Campanhas</h2>
+                <p>Utilize a interface React para gerenciar campanhas.</p>
+            </div>
+        </div>
     </div>
-    
+
     <div id="createModal" class="modal">
         <div class="modal-content">
             <h3>➕ Nova Instância WhatsApp</h3>


### PR DESCRIPTION
## Summary
- add Campanhas navigation and placeholder section to HTML interface
- enhance React Campaigns form with media attachments and deletion with refresh

## Testing
- `python -m py_compile whatsflow-real.py`
- `cd frontend && CI=true yarn test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c9d8f3b8832fa29efb6062084075