### PR TITLE
Remove stray campaign scheduler marker

### DIFF
--- a/whatsflow-real.py
+++ b/whatsflow-real.py
@@ -3832,7 +3832,6 @@ def send_via_baileys(phone: str, message: str, instance_id: str = "default") -> 
     return success
 
 
- codex/add-background-task-for-campaign-messages
 async def campaign_scheduler():
     """Periodically check and send scheduled campaign messages."""
     while True:


### PR DESCRIPTION
## Summary
- remove leftover `codex/add-background-task-for-campaign-messages` line near campaign scheduler definition in `whatsflow-real.py`

## Testing
- `python -m py_compile whatsflow-real.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1d1778cb8832fbdce992c35e0f356