### PR TITLE
Use contact_phone in campaign scheduler

### DIFF
--- a/whatsflow-real.py
+++ b/whatsflow-real.py
@@ -4006,14 +4006,14 @@ async def campaign_scheduler():
             cursor = conn.cursor()
             cursor.execute(
                 """
-                SELECT id, phone, message, instance_id, weekdays, last_sent_at
+                SELECT id, contact_phone, message, instance_id, weekdays, last_sent_at
                 FROM campaign_messages
                 WHERE send_time = ?
                 """,
                 (current_time,),
             )
             rows = cursor.fetchall()
-            for msg_id, phone, message, instance_id, weekdays, last_sent_at in rows:
+            for msg_id, contact_phone, message, instance_id, weekdays, last_sent_at in rows:
                 if weekdays:
                     days = [int(d) for d in weekdays.split(',') if d.strip()]
                     if weekday not in days:
@@ -4025,7 +4025,7 @@ async def campaign_scheduler():
                             continue
                     except Exception:
                         pass
-                if send_via_baileys(phone, message, instance_id or 'default'):
+                if send_via_baileys(contact_phone, message, instance_id or 'default'):
                     cursor.execute(
                         "UPDATE campaign_messages SET last_sent_at = ? WHERE id = ?",
                         (now.isoformat(), msg_id),


### PR DESCRIPTION
## Summary
- Fix campaign scheduler query to select `contact_phone` instead of missing `phone` column.
- Adjust scheduler loop to send messages using `contact_phone` field.

## Testing
- `python -m py_compile whatsflow-real.py`
- `python - <<'PY' ...` (run campaign scheduler once with test data)


------
https://chatgpt.com/codex/tasks/task_e_68c1de261818832f9327d6e88820637e