### PR TITLE
feat: add campaign scheduling wizard

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2400,3 +2400,94 @@ body {
 .close-qr-btn:hover {
   background: #c53030;
 }
+
+/* Campaigns section */
+.campaigns-section {
+  margin-top: 2rem;
+}
+
+.campaigns-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.campaigns-header button {
+  background: #3182ce;
+  color: #fff;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.campaign-card {
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+  padding: 1rem;
+  margin-bottom: 1rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.campaign-actions button {
+  margin-left: 0.5rem;
+}
+
+/* Modal form */
+.campaign-form {
+  background: #fff;
+  padding: 1.5rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+}
+
+.form-row {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 1rem;
+}
+
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.messages-preview {
+  margin-top: 1rem;
+}
+
+.message-card {
+  background: #f9f9f9;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  padding: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.message-card-header {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 0.25rem;
+}
+
+.message-card-actions button {
+  margin-left: 0.25rem;
+}
+
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0,0,0,0.5);
+  z-index: 1000;
+}

--- a/frontend/src/components/Campaigns.js
+++ b/frontend/src/components/Campaigns.js
@@ -6,16 +6,27 @@ const API = `${BACKEND_URL}/api`;
 
 // Form component for creating/editing campaigns
 function CampaignForm({ initialData, onSave, onCancel }) {
+  // Step control
+  const [step, setStep] = useState(1);
+
+  // Basic info
   const [name, setName] = useState(initialData?.name || '');
   const [recurrence, setRecurrence] = useState(initialData?.recurrence || 'daily');
   const [time, setTime] = useState(initialData?.time || '');
   const [day, setDay] = useState(initialData?.day || 'monday');
-  const [message, setMessage] = useState(initialData?.message || '');
-  const [media, setMedia] = useState(null);
   const [instances, setInstances] = useState([]);
   const [instanceId, setInstanceId] = useState(initialData?.instance_id || '');
+
+  // Groups
   const [groups, setGroups] = useState([]);
   const [selectedGroups, setSelectedGroups] = useState(initialData?.groups || []);
+
+  // Scheduled messages
+  const [scheduledMessages, setScheduledMessages] = useState(initialData?.messages || []);
+  const [currentMessage, setCurrentMessage] = useState('');
+  const [currentMedia, setCurrentMedia] = useState(null);
+  const [currentDay, setCurrentDay] = useState('monday');
+  const [editingIndex, setEditingIndex] = useState(-1);
 
   useEffect(() => {
     const fetchInstances = async () => {
@@ -46,6 +57,46 @@ function CampaignForm({ initialData, onSave, onCancel }) {
     fetchGroups();
   }, [instanceId]);
 
+  const addOrUpdateMessage = () => {
+    const msg = currentMessage.trim();
+    if (!msg && !currentMedia) return;
+    const entry = {
+      day: recurrence === 'daily' ? 'daily' : currentDay,
+      text: msg,
+      media: currentMedia
+    };
+    setScheduledMessages(prev => {
+      const copy = [...prev];
+      if (editingIndex >= 0) {
+        copy[editingIndex] = entry;
+      } else {
+        copy.push(entry);
+      }
+      return copy;
+    });
+    setCurrentMessage('');
+    setCurrentMedia(null);
+    setEditingIndex(-1);
+  };
+
+  const editMessage = (index) => {
+    const msg = scheduledMessages[index];
+    setCurrentMessage(msg.text);
+    setCurrentMedia(null);
+    setCurrentDay(msg.day);
+    setEditingIndex(index);
+  };
+
+  const removeMessage = (index) => {
+    setScheduledMessages(prev => prev.filter((_, i) => i !== index));
+  };
+
+  const toggleGroup = (groupId) => {
+    setSelectedGroups(prev =>
+      prev.includes(groupId) ? prev.filter(id => id !== groupId) : [...prev, groupId]
+    );
+  };
+
   const handleSubmit = async (e) => {
     e.preventDefault();
     const formData = new FormData();
@@ -57,10 +108,19 @@ function CampaignForm({ initialData, onSave, onCancel }) {
     }
     formData.append('instance_id', instanceId);
     formData.append('groups', JSON.stringify(selectedGroups));
-    formData.append('message', message);
-    if (media) {
-      formData.append('media', media);
-    }
+    formData.append(
+      'messages',
+      JSON.stringify(
+        scheduledMessages.map((m, idx) => ({
+          day: m.day,
+          text: m.text,
+          media: m.media ? `media_${idx}` : null
+        }))
+      )
+    );
+    scheduledMessages.forEach((m, idx) => {
+      if (m.media) formData.append(`media_${idx}`, m.media);
+    });
 
     try {
       if (initialData?.id) {
@@ -79,82 +139,130 @@ function CampaignForm({ initialData, onSave, onCancel }) {
     }
   };
 
-  const toggleGroup = (groupId) => {
-    setSelectedGroups(prev =>
-      prev.includes(groupId) ? prev.filter(id => id !== groupId) : [...prev, groupId]
-    );
-  };
+  const nextStep = () => setStep(s => s + 1);
+  const prevStep = () => setStep(s => s - 1);
 
   return (
     <form className="campaign-form" onSubmit={handleSubmit}>
-      <div className="form-row">
-        <label>Nome da Campanha</label>
-        <input value={name} onChange={e => setName(e.target.value)} required />
-      </div>
-      <div className="form-row">
-        <label>Instância</label>
-        <select value={instanceId} onChange={e => setInstanceId(e.target.value)} required>
-          <option value="">Selecione...</option>
-          {instances.map(inst => (
-            <option key={inst.id} value={inst.id}>{inst.name}</option>
-          ))}
-        </select>
-      </div>
-      <div className="form-row">
-        <label>Recorrência</label>
-        <select value={recurrence} onChange={e => setRecurrence(e.target.value)}>
-          <option value="daily">Diária</option>
-          <option value="weekly">Semanal</option>
-        </select>
-      </div>
-      {recurrence === 'weekly' && (
+      {step === 1 && (
+        <>
+          <div className="form-row">
+            <label>Nome da Campanha</label>
+            <input value={name} onChange={e => setName(e.target.value)} required />
+          </div>
+          <div className="form-row">
+            <label>Instância</label>
+            <select value={instanceId} onChange={e => setInstanceId(e.target.value)} required>
+              <option value="">Selecione...</option>
+              {instances.map(inst => (
+                <option key={inst.id} value={inst.id}>{inst.name}</option>
+              ))}
+            </select>
+          </div>
+          <div className="form-row">
+            <label>Recorrência</label>
+            <select value={recurrence} onChange={e => setRecurrence(e.target.value)}>
+              <option value="daily">Diária</option>
+              <option value="weekly">Semanal</option>
+            </select>
+          </div>
+          {recurrence === 'weekly' && (
+            <div className="form-row">
+              <label>Dia da Semana</label>
+              <select value={day} onChange={e => setDay(e.target.value)}>
+                <option value="monday">Segunda</option>
+                <option value="tuesday">Terça</option>
+                <option value="wednesday">Quarta</option>
+                <option value="thursday">Quinta</option>
+                <option value="friday">Sexta</option>
+                <option value="saturday">Sábado</option>
+                <option value="sunday">Domingo</option>
+              </select>
+            </div>
+          )}
+          <div className="form-row">
+            <label>Horário</label>
+            <input type="time" value={time} onChange={e => setTime(e.target.value)} required />
+          </div>
+        </>
+      )}
+
+      {step === 2 && (
         <div className="form-row">
-          <label>Dia da Semana</label>
-          <select value={day} onChange={e => setDay(e.target.value)}>
-            <option value="monday">Segunda</option>
-            <option value="tuesday">Terça</option>
-            <option value="wednesday">Quarta</option>
-            <option value="thursday">Quinta</option>
-            <option value="friday">Sexta</option>
-            <option value="saturday">Sábado</option>
-            <option value="sunday">Domingo</option>
-          </select>
+          <label>Grupos</label>
+          <div className="groups-list">
+            {groups.map(g => (
+              <label key={g.id} className="group-item">
+                <input
+                  type="checkbox"
+                  checked={selectedGroups.includes(g.id)}
+                  onChange={() => toggleGroup(g.id)}
+                />
+                {g.subject || g.name || g.id}
+              </label>
+            ))}
+          </div>
         </div>
       )}
-      <div className="form-row">
-        <label>Horário</label>
-        <input type="time" value={time} onChange={e => setTime(e.target.value)} required />
-      </div>
-      <div className="form-row">
-        <label>Grupos</label>
-        <div className="groups-list">
-          {groups.map(g => (
-            <label key={g.id} className="group-item">
-              <input
-                type="checkbox"
-                checked={selectedGroups.includes(g.id)}
-                onChange={() => toggleGroup(g.id)}
-              />
-              {g.subject || g.name || g.id}
-            </label>
-          ))}
+
+      {step === 3 && (
+        <div className="form-row">
+          {recurrence === 'weekly' && (
+            <div className="form-row">
+              <label>Dia</label>
+              <select value={currentDay} onChange={e => setCurrentDay(e.target.value)}>
+                <option value="monday">Segunda</option>
+                <option value="tuesday">Terça</option>
+                <option value="wednesday">Quarta</option>
+                <option value="thursday">Quinta</option>
+                <option value="friday">Sexta</option>
+                <option value="saturday">Sábado</option>
+                <option value="sunday">Domingo</option>
+              </select>
+            </div>
+          )}
+          <label>Mensagem</label>
+          <textarea value={currentMessage} onChange={e => setCurrentMessage(e.target.value)} />
+          <label>Mídia</label>
+          <input
+            type="file"
+            accept="image/*,audio/*,video/*"
+            onChange={e => setCurrentMedia(e.target.files[0])}
+          />
+          <button type="button" onClick={addOrUpdateMessage} className="add-message-btn">
+            {editingIndex >= 0 ? 'Atualizar' : 'Adicionar'} mensagem
+          </button>
+          <div className="messages-preview">
+            {scheduledMessages.map((m, idx) => (
+              <div key={idx} className="message-card">
+                <div className="message-card-header">
+                  <strong>{m.day === 'daily' ? 'Todos os dias' : m.day}</strong>
+                  <div className="message-card-actions">
+                    <button type="button" onClick={() => editMessage(idx)}>Editar</button>
+                    <button type="button" onClick={() => removeMessage(idx)}>Excluir</button>
+                  </div>
+                </div>
+                <p>{m.text}</p>
+                {m.media && <small>Mídia anexada</small>}
+              </div>
+            ))}
+          </div>
         </div>
-      </div>
-      <div className="form-row">
-        <label>Mensagem</label>
-        <textarea value={message} onChange={e => setMessage(e.target.value)} />
-      </div>
-      <div className="form-row">
-        <label>Mídia</label>
-        <input
-          type="file"
-          accept="text/plain,image/*,audio/*,video/*"
-          onChange={e => setMedia(e.target.files[0])}
-        />
-      </div>
+      )}
+
       <div className="form-actions">
-        <button type="button" onClick={onCancel}>Cancelar</button>
-        <button type="submit">Salvar</button>
+        {step > 1 && (
+          <button type="button" onClick={prevStep}>Voltar</button>
+        )}
+        {step < 3 && (
+          <button type="button" onClick={nextStep}>Próximo</button>
+        )}
+        {step === 3 && (
+          <>
+            <button type="button" onClick={onCancel}>Cancelar</button>
+            <button type="submit">Salvar</button>
+          </>
+        )}
       </div>
     </form>
   );
@@ -210,11 +318,13 @@ export default function Campaigns() {
       </div>
 
       {showForm && (
-        <CampaignForm
-          initialData={editing}
-          onSave={handleSave}
-          onCancel={() => { setShowForm(false); setEditing(null); }}
-        />
+        <div className="modal-overlay">
+          <CampaignForm
+            initialData={editing}
+            onSave={handleSave}
+            onCancel={() => { setShowForm(false); setEditing(null); }}
+          />
+        </div>
       )}
 
       <div className="campaigns-list">


### PR DESCRIPTION
## Summary
- add modal-based campaigns section with stepper flow
- support group selection and scheduled messages with media previews
- style campaigns and message cards with modern UI

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68c219b24b24832fb9361806ccab6067