### PR TITLE
Remove stray codex placeholder

### DIFF
--- a/whatsflow-real.py
+++ b/whatsflow-real.py
@@ -3916,7 +3916,6 @@ def send_scheduled_message(
             logger.error(f"Erro ao carregar mídia '{media_path}': {e}")
             return False
     try:
- codex/update-fetch-url-and-create-api-handler
         return baileys_send_message(instance_id, data)
     except BaileysUnavailable:
 


### PR DESCRIPTION
## Summary
- remove placeholder line referencing codex from scheduled message function

## Testing
- `python -m py_compile whatsflow-real.py`


------
https://chatgpt.com/codex/tasks/task_e_68c21ce92924832fac87254116f07df3