### PR TITLE
feat(frontend): add campaign cards grid

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2422,19 +2422,111 @@ body {
   cursor: pointer;
 }
 
-.campaign-card {
-  background: #fff;
-  border-radius: 8px;
-  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
-  padding: 1rem;
-  margin-bottom: 1rem;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
+.campaigns-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 1.5rem;
 }
 
-.campaign-actions button {
-  margin-left: 0.5rem;
+.campaign-card {
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 4px 10px rgba(0,0,0,0.05);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.card-actions {
+  margin-top: auto;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.card-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  background: #edf2f7;
+  color: #4a5568;
+  border: none;
+  border-radius: 6px;
+  padding: 0.4rem 0.75rem;
+  cursor: pointer;
+  transition: background 0.2s;
+  font-size: 0.875rem;
+}
+
+.card-btn:hover {
+  background: #e2e8f0;
+  color: #2d3748;
+}
+
+.card-btn.primary {
+  background: #3182ce;
+  color: #fff;
+}
+
+.card-btn.primary:hover {
+  background: #2b6cb0;
+}
+
+.modal {
+  background: #fff;
+  padding: 1.5rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+  max-width: 500px;
+  width: 100%;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.schedule-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.schedule-day {
+  background: #f7fafc;
+  border-radius: 6px;
+  padding: 0.5rem;
+  min-height: 80px;
+  display: flex;
+  flex-direction: column;
+}
+
+.schedule-day h4 {
+  font-size: 0.75rem;
+  color: #4a5568;
+  margin-bottom: 0.25rem;
+}
+
+.schedule-day ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.schedule-day li {
+  font-size: 0.75rem;
+  background: #edf2f7;
+  color: #2d3748;
+  border-radius: 4px;
+  padding: 0.25rem;
 }
 
 /* Modal form */

--- a/frontend/src/components/Campaigns.js
+++ b/frontend/src/components/Campaigns.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import axios from 'axios';
+import { Users, Calendar } from 'lucide-react';
 
 const BACKEND_URL = process.env.REACT_APP_BACKEND_URL;
 const API = `${BACKEND_URL}/api`;
@@ -268,11 +269,184 @@ function CampaignForm({ initialData, onSave, onCancel }) {
   );
 }
 
+// Modal for selecting groups
+function GroupModal({ campaign, onClose, onSaved }) {
+  const [instances, setInstances] = useState([]);
+  const [instanceId, setInstanceId] = useState('');
+  const [groups, setGroups] = useState([]);
+  const [selected, setSelected] = useState(campaign.groups || []);
+
+  useEffect(() => {
+    const loadInstances = async () => {
+      try {
+        const res = await axios.get(`${API}/whatsapp/instances`);
+        setInstances(res.data || []);
+      } catch (err) {
+        console.error('Erro ao buscar instâncias', err);
+      }
+    };
+    loadInstances();
+  }, []);
+
+  useEffect(() => {
+    if (!instanceId) return;
+    const loadGroups = async () => {
+      try {
+        const res = await axios.get(`${API}/groups/${instanceId}`);
+        setGroups(res.data || []);
+      } catch (err) {
+        console.error('Erro ao buscar grupos', err);
+      }
+    };
+    loadGroups();
+  }, [instanceId]);
+
+  const toggle = (id) => {
+    setSelected(prev =>
+      prev.includes(id) ? prev.filter(g => g !== id) : [...prev, id]
+    );
+  };
+
+  const save = async () => {
+    try {
+      await axios.put(`${API}/campaigns/${campaign.id}`, { groups: selected });
+      onSaved();
+    } catch (err) {
+      console.error('Erro ao salvar grupos', err);
+      alert('Erro ao salvar grupos');
+    }
+  };
+
+  return (
+    <div className="modal">
+      <h3>Selecionar grupos</h3>
+      <div className="form-row">
+        <label>Instância</label>
+        <select value={instanceId} onChange={e => setInstanceId(e.target.value)}>
+          <option value="">Selecione...</option>
+          {instances.map(inst => (
+            <option key={inst.id} value={inst.id}>{inst.name}</option>
+          ))}
+        </select>
+      </div>
+      {groups.length > 0 && (
+        <div className="form-row groups-list">
+          {groups.map(g => (
+            <label key={g.id} className="group-item">
+              <input
+                type="checkbox"
+                checked={selected.includes(g.id)}
+                onChange={() => toggle(g.id)}
+              />
+              {g.subject || g.name || g.id}
+            </label>
+          ))}
+        </div>
+      )}
+      <div className="modal-actions">
+        <button type="button" className="card-btn" onClick={onClose}>Cancelar</button>
+        <button type="button" className="card-btn primary" onClick={save}>Salvar</button>
+      </div>
+    </div>
+  );
+}
+
+// Modal for scheduling messages
+function ScheduleModal({ campaign, onClose }) {
+  const dayLabels = {
+    monday: 'Segunda',
+    tuesday: 'Terça',
+    wednesday: 'Quarta',
+    thursday: 'Quinta',
+    friday: 'Sexta',
+    saturday: 'Sábado',
+    sunday: 'Domingo'
+  };
+
+  const [messagesByDay, setMessagesByDay] = useState({
+    monday: [], tuesday: [], wednesday: [], thursday: [], friday: [], saturday: [], sunday: []
+  });
+  const [text, setText] = useState('');
+  const [day, setDay] = useState('monday');
+
+  const loadMessages = async () => {
+    try {
+      const res = await axios.get(`${API}/campaigns/${campaign.id}/messages`);
+      const byDay = {
+        monday: [], tuesday: [], wednesday: [], thursday: [], friday: [], saturday: [], sunday: []
+      };
+      (res.data.messages || []).forEach(m => {
+        if (m.next_run) {
+          const d = new Date(m.next_run);
+          const key = ['sunday','monday','tuesday','wednesday','thursday','friday','saturday'][d.getDay()];
+          byDay[key].push(m);
+        }
+      });
+      setMessagesByDay(byDay);
+    } catch (err) {
+      console.error('Erro ao carregar agenda', err);
+    }
+  };
+
+  useEffect(() => {
+    loadMessages();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const add = async () => {
+    if (!text.trim()) return;
+    try {
+      await axios.post(`${API}/campaigns/${campaign.id}/messages`, { content: text, weekday: day });
+      setText('');
+      await loadMessages();
+    } catch (err) {
+      console.error('Erro ao agendar mensagem', err);
+      alert('Erro ao agendar mensagem');
+    }
+  };
+
+  return (
+    <div className="modal schedule-modal">
+      <h3>Agenda de mensagens</h3>
+      <div className="schedule-grid">
+        {Object.keys(dayLabels).map(k => (
+          <div key={k} className="schedule-day">
+            <h4>{dayLabels[k]}</h4>
+            <ul>
+              {messagesByDay[k].map(m => (
+                <li key={m.id}>{m.content}</li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+      <div className="form-row">
+        <label>Dia</label>
+        <select value={day} onChange={e => setDay(e.target.value)}>
+          {Object.keys(dayLabels).map(k => (
+            <option key={k} value={k}>{dayLabels[k]}</option>
+          ))}
+        </select>
+      </div>
+      <div className="form-row">
+        <label>Mensagem</label>
+        <input value={text} onChange={e => setText(e.target.value)} />
+      </div>
+      <div className="modal-actions">
+        <button type="button" className="card-btn" onClick={onClose}>Fechar</button>
+        <button type="button" className="card-btn primary" onClick={add}>Adicionar</button>
+      </div>
+    </div>
+  );
+}
+
 export default function Campaigns() {
   const [campaigns, setCampaigns] = useState([]);
   const [loading, setLoading] = useState(true);
   const [showForm, setShowForm] = useState(false);
   const [editing, setEditing] = useState(null);
+  const [groupModal, setGroupModal] = useState(null);
+  const [scheduleModal, setScheduleModal] = useState(null);
 
   const fetchCampaigns = async () => {
     try {
@@ -327,7 +501,26 @@ export default function Campaigns() {
         </div>
       )}
 
-      <div className="campaigns-list">
+      {groupModal && (
+        <div className="modal-overlay">
+          <GroupModal
+            campaign={groupModal}
+            onClose={() => setGroupModal(null)}
+            onSaved={() => { setGroupModal(null); fetchCampaigns(); }}
+          />
+        </div>
+      )}
+
+      {scheduleModal && (
+        <div className="modal-overlay">
+          <ScheduleModal
+            campaign={scheduleModal}
+            onClose={() => setScheduleModal(null)}
+          />
+        </div>
+      )}
+
+      <div className="campaigns-grid">
         {campaigns.map(c => (
           <div key={c.id} className="campaign-card">
             <div className="campaign-info">
@@ -339,9 +532,11 @@ export default function Campaigns() {
                 </div>
               )}
             </div>
-            <div className="campaign-actions">
-              <button onClick={() => { setEditing(c); setShowForm(true); }}>Editar</button>
-              <button onClick={() => handleDelete(c.id)}>Excluir</button>
+            <div className="card-actions">
+              <button className="card-btn" onClick={() => setGroupModal(c)}><Users size={16}/> Selecionar grupos</button>
+              <button className="card-btn" onClick={() => setScheduleModal(c)}><Calendar size={16}/> Agendar mensagens</button>
+              <button className="card-btn" onClick={() => { setEditing(c); setShowForm(true); }}>Editar</button>
+              <button className="card-btn" onClick={() => handleDelete(c.id)}>Excluir</button>
             </div>
           </div>
         ))}


### PR DESCRIPTION
## Summary
- refactor campaigns page to show grid of cards
- add group selection and schedule modals per campaign
- style campaigns view with ManyChat-like cards and buttons

## Testing
- `cd frontend && yarn test --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68c220a86384832fb68cf2f851f0a3cf