### PR TITLE
Remove extraneous codex line from campaigns insert

### DIFF
--- a/whatsflow-real.py
+++ b/whatsflow-real.py
@@ -6259,7 +6259,6 @@ class WhatsFlowRealHandler(BaseHTTPRequestHandler):
                     data['name'],
                     data.get('description'),
                     data.get('recurrence'),
- codex/create-campaigns-database-and-rest-endpoints
                     data.get('send_time'),
                     data.get('weekday'),
                     data.get('timezone', 'America/Sao_Paulo'),


### PR DESCRIPTION
## Summary
- remove stray `codex/create-campaigns-database-and-rest-endpoints` line in `init_db`

## Testing
- `python -m py_compile whatsflow-real.py`


------
https://chatgpt.com/codex/tasks/task_e_68c225a578d4832fa42953274b7945d7