### PR TITLE
Introduce campaign scheduling with group cards and media support

### DIFF
--- a/baileys_service/server.js
+++ b/baileys_service/server.js
@@ -432,12 +432,32 @@ app.post('/send/:instanceId', async (req, res) => {
         if (type === 'text') {
             await instance.sock.sendMessage(jid, { text: message });
         } else if (type === 'image' && req.body.imageData) {
-            // Handle image sending (base64)
             const buffer = Buffer.from(req.body.imageData, 'base64');
-            await instance.sock.sendMessage(jid, { 
+            await instance.sock.sendMessage(jid, {
                 image: buffer,
                 caption: message || ''
             });
+        } else if (type === 'audio' && req.body.audioData) {
+            const buffer = Buffer.from(req.body.audioData, 'base64');
+            await instance.sock.sendMessage(jid, {
+                audio: buffer,
+                mimetype: req.body.mimetype || 'audio/mpeg'
+            });
+        } else if (type === 'video' && req.body.videoData) {
+            const buffer = Buffer.from(req.body.videoData, 'base64');
+            await instance.sock.sendMessage(jid, {
+                video: buffer,
+                caption: message || ''
+            });
+        } else if (type === 'document' && req.body.documentData) {
+            const buffer = Buffer.from(req.body.documentData, 'base64');
+            await instance.sock.sendMessage(jid, {
+                document: buffer,
+                caption: message || '',
+                fileName: req.body.fileName || 'file'
+            });
+        } else {
+            return res.status(400).json({ error: 'Tipo de mensagem não suportado' });
         }
         
         console.log(`📤 Mensagem enviada da instância ${instanceId} para ${to}`);

--- a/tests/test_baileys_unavailable.py
+++ b/tests/test_baileys_unavailable.py
@@ -1,0 +1,40 @@
+import unittest
+from unittest.mock import patch
+import urllib.request
+from urllib.error import URLError
+
+# Helper functions mimicking fetch layer error handling
+
+def fetch_groups():
+    try:
+        urllib.request.urlopen("http://127.0.0.1:3002/groups/test", timeout=1)
+        return ""  # Success path is not relevant for this test
+    except URLError:
+        return "Serviço Baileys indisponível na porta 3002"
+
+def send_message():
+    try:
+        req = urllib.request.Request(
+            "http://127.0.0.1:3002/send/test",
+            data=b"{}",
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        urllib.request.urlopen(req, timeout=1)
+        return ""
+    except URLError:
+        return "Serviço Baileys indisponível na porta 3002"
+
+
+class BaileysUnavailableTest(unittest.TestCase):
+    @patch("urllib.request.urlopen", side_effect=URLError("down"))
+    def test_groups_unavailable_message(self, mock_open):
+        self.assertEqual(fetch_groups(), "Serviço Baileys indisponível na porta 3002")
+
+    @patch("urllib.request.urlopen", side_effect=URLError("down"))
+    def test_send_unavailable_message(self, mock_open):
+        self.assertEqual(send_message(), "Serviço Baileys indisponível na porta 3002")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_campaigns.py
+++ b/tests/test_campaigns.py
@@ -1,0 +1,16 @@
+import importlib.util
+import pathlib
+
+spec = importlib.util.spec_from_file_location("wfreal", pathlib.Path(__file__).resolve().parent.parent / "whatsflow-real.py")
+wf = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(wf)
+
+
+def test_compute_next_run_daily_timezone():
+    dt = wf.compute_next_run("daily", 0, "00:00")
+    assert dt.tzinfo == wf.BR_TZ
+
+
+def test_compute_next_run_weekly_day():
+    dt = wf.compute_next_run("weekly", 3, "12:00")
+    assert dt.weekday() == 3


### PR DESCRIPTION
## Summary
- add campaign tables and background scheduler using Brazil timezone for daily/weekly dispatch
- expose campaign management UI under Groups allowing group selection and message scheduling
- extend Baileys send endpoint to accept audio, video and document attachments
- cover scheduling helper with tests

## Testing
- `python -m py_compile whatsflow-real.py`
- `python tests/test_baileys_unavailable.py`
- `pytest tests/test_campaigns.py`


------
https://chatgpt.com/codex/tasks/task_e_68c18f57f39c832f833da7829d0720ff