### PR TITLE
Ensure asyncio is always imported

### DIFF
--- a/whatsflow-real.py
+++ b/whatsflow-real.py
@@ -26,6 +26,8 @@ from zoneinfo import ZoneInfo
 
 import base64
 
+import asyncio
+
 # Try to import websockets, fallback gracefully if not available
 try:
     import websockets


### PR DESCRIPTION
## Summary
- Ensure `asyncio` is always available by importing it outside the WebSocket try/except

## Testing
- `python -m py_compile whatsflow-real.py`


------
https://chatgpt.com/codex/tasks/task_e_68c2378070d4832fb52cca027f059a5f