### PR TITLE
Ensure asyncio is always imported

### DIFF
--- a/whatsflow-real.py
+++ b/whatsflow-real.py
@@ -26,6 +26,8 @@ from zoneinfo import ZoneInfo
 
 import base64
 
+import asyncio
+
 # Try to import websockets, fallback gracefully if not available
 try:
     import websockets
@@ -6634,11 +6636,6 @@ def main():
     server_thread.daemon = True
     server_thread.start()
 
-    # Launch campaign scheduler task after server starts
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-    loop.create_task(campaign_message_scheduler())
-
     print("✅ WhatsFlow Professional configurado!")
     print(f"🌐 Interface: http://localhost:{PORT}")
     print(f"🔌 WebSocket: ws://localhost:{WEBSOCKET_PORT}")
@@ -6648,7 +6645,7 @@ def main():
     print()
 
     try:
-        loop.run_forever()
+        server_thread.join()
     except KeyboardInterrupt:
         print("\n👋 WhatsFlow Professional finalizado!")
         baileys_manager.stop_baileys()


### PR DESCRIPTION
## Summary
- Ensure `asyncio` is always available by importing it outside the WebSocket try/except
- Remove undefined campaign scheduler task and rely on HTTP server thread to keep process alive

## Testing
- `python -m py_compile whatsflow-real.py`


------
https://chatgpt.com/codex/tasks/task_e_68c2378070d4832fb52cca027f059a5f