### PR TITLE
Fix duplicate timezone in whatsflow-real

### DIFF
--- a/whatsflow-real.py
+++ b/whatsflow-real.py
@@ -51,11 +51,9 @@ WEBSOCKET_PORT = 8890
 # Path to React build for serving the frontend
 FRONTEND_BUILD_DIR = Path(__file__).resolve().parent / "frontend" / "build"
 # codex/redesign-grupos-tab-with-campaign-button-1n5c7l
- codex/refactor-conditional-logic-in-whatsflowrealhandler
 
 
 # Brazil timezone for scheduling
-BR_TZ = ZoneInfo("America/Sao_Paulo")
 
 
 
@@ -77,7 +75,6 @@ def compute_next_run(schedule_type: str, weekday: int, time_str: str) -> datetim
 # WebSocket clients management
 if WEBSOCKETS_AVAILABLE:
     websocket_clients: Set[websockets.WebSocketServerProtocol] = set()
- codex/refactor-conditional-logic-in-whatsflowrealhandler
 
 # codex/redesign-grupos-tab-with-campaign-button-1n5c7l
 # Configure logging


### PR DESCRIPTION
## Summary
- ensure frontend build path constant is flush with start of line
- drop redundant Brazil timezone declaration and stray placeholder lines

## Testing
- `python -m py_compile whatsflow-real.py`
- `timeout 3s python3 whatsflow-real.py`

------
https://chatgpt.com/codex/tasks/task_e_68c3072110b4832fba7ba2d8a21b36cf