### PR TITLE
fix: 404 on missing static assets

### DIFF
--- a/whatsflow-real.py
+++ b/whatsflow-real.py
@@ -1038,6 +1038,10 @@ class WhatsFlowRealHandler(BaseHTTPRequestHandler):
             self.send_error(404, "Not Found")
             return
         if not file_path.exists():
+            # Only fallback to index.html for extensionless paths
+            if Path(path).suffix:
+                self.send_error(404, "Not Found")
+                return
             file_path = FRONTEND_BUILD_DIR / 'index.html'
         try:
             with open(file_path, 'rb') as f:


### PR DESCRIPTION
## Summary
- Serve `index.html` only for extensionless frontend requests
- Return 404 for missing static assets so valid files load correctly

## Testing
- `python -m py_compile whatsflow-real.py`
- `pytest`
- `python - <<'PY' ... PY`

------
https://chatgpt.com/codex/tasks/task_e_68c30a123430832f8c2025a943b32eaa