### PR TITLE
Remove duplicate BR_TZ definition

### DIFF
--- a/whatsflow-real.py
+++ b/whatsflow-real.py
@@ -51,12 +51,6 @@ WEBSOCKET_PORT = 8890
 # Path to React build for serving the frontend
 FRONTEND_BUILD_DIR = Path(__file__).resolve().parent / "frontend" / "build"
 # codex/redesign-grupos-tab-with-campaign-button-1n5c7l
-
-
-# Brazil timezone for scheduling
-
-
-
 def compute_next_run(schedule_type: str, weekday: int, time_str: str) -> datetime:
     """Compute next datetime for a campaign message based on schedule."""
     now = datetime.now(BR_TZ)


### PR DESCRIPTION
## Summary
- consolidate Brazil timezone configuration into a single `BR_TZ` definition in `whatsflow-real.py`
- remove stray comment referencing a second timezone definition

## Testing
- `python3 whatsflow-real.py`
- `pytest` *(fails: `AttributeError: <module 'app'... has no attribute 'baileys_post'`, `KeyError: 'campaign_id'`)*

------
https://chatgpt.com/codex/tasks/task_e_68c30a13319c832fb3acf5adbc6703f5