### PR TITLE
Add campaign creation endpoints and integrate frontend

### DIFF
--- a/frontend/src/components/Groups.js
+++ b/frontend/src/components/Groups.js
@@ -15,15 +15,16 @@ export default function Groups() {
   const BACKEND_URL = process.env.REACT_APP_BACKEND_URL;
   const API = `${BACKEND_URL}/api`;
 
+  const fetchCampaigns = async () => {
+    try {
+      const res = await axios.get(`${API}/campaigns`);
+      setCampaigns(res.data.campaigns || []);
+    } catch (err) {
+      console.error('Failed to load campaigns', err);
+    }
+  };
+
   useEffect(() => {
-    const fetchCampaigns = async () => {
-      try {
-        const res = await axios.get(`${API}/campaigns`);
-        setCampaigns(res.data.campaigns || []);
-      } catch (err) {
-        console.error('Failed to load campaigns', err);
-      }
-    };
     fetchCampaigns();
   }, [API]);
 
@@ -31,9 +32,8 @@ export default function Groups() {
     e.preventDefault();
     if (!name.trim()) return;
     try {
-      const res = await axios.post(`${API}/campaigns`, { name: name.trim() });
-      const newCampaign = res.data;
-      setCampaigns([...campaigns, newCampaign]);
+      await axios.post(`${API}/campaigns`, { name: name.trim() });
+      await fetchCampaigns();
       setName('');
       setShowModal(false);
     } catch (err) {


### PR DESCRIPTION
## Summary
- add Campaign model and API routes to create and list campaigns
- update Groups component to load campaigns from backend and submit new ones

## Testing
- `pytest -q` (fails: KeyError 'campaign_id', AttributeError, etc.)
- `pytest tests/test_campaigns.py -q`
- `npm test -- --watchAll=false` (fails: No tests found)


------
https://chatgpt.com/codex/tasks/task_e_68c3127a227c832f9e02a66ba8e95175