### PR TITLE
feat: schedule campaign messages

### DIFF
--- a/frontend/src/components/Groups.js
+++ b/frontend/src/components/Groups.js
@@ -80,19 +80,10 @@ export default function Groups() {
   const scheduleMessage = async (e) => {
     e.preventDefault();
     try {
-      await axios.post(`${API}/campaigns/${selectedCampaign.id}/messages`, {
-        schedule_type: 'once',
-        weekday: null,
-        send_time: sendTime,
+      await axios.post(`${API}/campaigns/${selectedCampaign.id}/schedule`, {
         message: messageText,
-        media_type: null,
-        media_data: null,
+        send_at: sendTime,
       });
-      setCampaigns(campaigns.map(c =>
-        c.id === selectedCampaign.id
-          ? { ...c, messages: [...(c.messages || []), { message: messageText, send_time: sendTime }] }
-          : c
-      ));
       setShowMessageModal(false);
       setMessageText('');
       setSendTime('');
@@ -192,9 +183,9 @@ export default function Groups() {
                 />
               </div>
               <div className="form-row">
-                <label>Horário</label>
+                <label>Data e horário</label>
                 <input
-                  type="time"
+                  type="datetime-local"
                   value={sendTime}
                   onChange={e => setSendTime(e.target.value)}
                   required


### PR DESCRIPTION
## Summary
- add campaign schedule endpoint and scheduler processing
- support text/datetime scheduling modal in Groups UI

## Testing
- `pytest tests/test_scheduler.py::TestScheduleAPI::test_post_schedule_stores_data -q`
- `pytest tests/test_scheduler.py::TestDispatcherProcessing::test_recurring_and_once -q`
- `pytest tests/test_scheduler_media.py -q`
- `pytest tests/test_scheduler.py::TestCampaignCRUD::test_campaign_crud -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3127b9ac0832fa0b75346a756f6de